### PR TITLE
Add Dockerfile for API

### DIFF
--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,11 @@
+__pycache__
+.git
+.venv
+venv
+*.pyc
+.env
+.gitignore
+tests/
+Dockerfile
+.dockerignore
+README.md

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY requirements.txt .
+RUN pip install uv && uv pip install --system -r requirements.txt
+
+COPY src/ src/
+COPY server.py .
+
+RUN useradd --create-home --shell /bin/bash appuser && chown -R appuser:appuser /app
+USER appuser

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -8,8 +8,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 COPY requirements.txt .
 RUN pip install uv && uv pip install --system -r requirements.txt
 
-COPY src/ src/
-COPY server.py .
+COPY . .
 
 RUN useradd --create-home --shell /bin/bash appuser && chown -R appuser:appuser /app
 USER appuser


### PR DESCRIPTION
Adds a production-ready Dockerfile for the API service.

- Base: Debian Trixie slim, Python 3.12
- Package manager: uv
- Non-root user (appuser)
- Layer-cached dependencies
- No CMD/ENTRYPOINT (service not started by container)